### PR TITLE
[ci skip] removing user @goanpeca

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,4 +51,3 @@ extra:
     - jni
     - czaki
     - jaimergp
-    - goanpeca


### PR DESCRIPTION
Manually removing @goanpeca from the maintainers list because the conda-forge-admin bot has not processed the request.

Closes #34